### PR TITLE
Minor update to  `How to Run an Avail Light Client` page

### DIFF
--- a/pages/docs/operate-a-node/run-a-light-client/0010-light-client.mdx
+++ b/pages/docs/operate-a-node/run-a-light-client/0010-light-client.mdx
@@ -31,12 +31,12 @@ You can find the latest release binary in the `avail-light` repository.
 
 In this example, you will download the light client and connect to an existing public network.
 
-1. Download the latest Avail light client [<ins>release</ins>](https://github.com/availproject/avail-light/releases/). The light client is available pre-built for different architectures. If you prefer building the light client yourself, see [<ins>build the Avail light client from source</ins>](#build-from-source).
+1. Download the latest Avail light client [<ins>release</ins>](https://github.com/availproject/avail-light/releases/) that is compatible with your system. The light client is available pre-built for different architectures. If you prefer building the light client yourself, see [<ins>build the Avail light client from source</ins>](#build-from-source).
 
 2.  Run the light client with the following pre-defined configuration file:
 
    ```bash
-   ./avail-light --network goldberg
+   ./avail-light-<light-client-binary-type> --network goldberg
    ```
 
 3.  If you want to supply your own configuration file (see [<ins>reference</ins>](https://github.com/availproject/avail-light#configuration-reference)), use:


### PR DESCRIPTION
Pushing minor changes to `How to Run an Avail Light Client` page as per @robin-rrt 's suggestions.
Basically, the terminal command to start running the light client needed a little more clarity.
