### PR TITLE
doc: fix typo in 0030-session-keys.mdx

### DIFF
--- a/pages/docs/operate-a-node/become-a-validator/0030-session-keys.mdx
+++ b/pages/docs/operate-a-node/become-a-validator/0030-session-keys.mdx
@@ -49,7 +49,7 @@ To generate it, we can the following command inside the server that is running o
 curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "author_rotateKeys", "params":[]}' http://localhost:9944
 
 # Restart our Node
-sudo systemctel restart avail.service
+sudo systemctl restart avail.service
 ```
 
 ### Docker/ Podman


### PR DESCRIPTION
Fix typo in operate-a-node/become-a-validator/0030-session-keys page - the command at line 52 seems to be "systemctl", instead of "systemctel"

See page at: https://docs.availproject.org/docs/operate-a-node/become-a-validator/0030-session-keys