### PR TITLE
Fixing two broken links brought to attention by Rishi

### DIFF
--- a/pages/docs/clash-of-nodes/overview.mdx
+++ b/pages/docs/clash-of-nodes/overview.mdx
@@ -36,7 +36,7 @@ The Clash of Nodes incentivized testnet is an opportunity for validators to enga
 
 The following table serves as a quick reference to understand the various elements that make up the Clash of Nodes campaign.
 
-If there are any unclear concepts about Avail, head over to the [<ins>glossary</ins>](/docs/glossary.mdx) for definitions and explanations.
+If there are any unclear concepts about Avail, head over to the [<ins>glossary</ins>](/docs/learn-about-avail/glossary.mdx) for definitions and explanations.
 
 | Concept                  | Description                                                                                                                                                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/pages/docs/learn-about-avail/consensus/babe.mdx
+++ b/pages/docs/learn-about-avail/consensus/babe.mdx
@@ -23,7 +23,7 @@ autonomously, offering probabilistic finality, or it can be integrated with a fi
 BABE operates on a slot-based algorithm, dividing time into eras, epochs, further segmented into slots. Within the Avail context, each slot lasts for twenty seconds, aligning with the
 target block time. In every slot, BABE determines an author (or potentially multiple authors) responsible for producing a block.
 <Callout type="info">
-If you're not familiar with Avail's terminology, you may check out our [<ins>Glossary</ins>](/docs/glossary).
+If you're not familiar with Avail's terminology, you may check out our [<ins>Glossary</ins>](/docs/learn-about-avail/glossary).
 </Callout>
 On Avail's explorer, you can observe the eras and epochs by navigating to the staking page and locating the information at the top-right corner.
 


### PR DESCRIPTION
Fixing broken links to the glossary page present inside the BABE and CON overview pages.