### PR TITLE
Fixing some broken links

### DIFF
--- a/CONTENT_DISCLAIMER.md
+++ b/CONTENT_DISCLAIMER.md
@@ -1,0 +1,7 @@
+Avail Documentation Third-Party Content Disclaimer
+
+The Avail Documentation Hub contains third-party content, including websites, products, and services, that are provided for informational purposes only.
+
+The Avail documentation serves as an industry public good and is made available under the MIT open source license.
+
+The Avail core team does not endorse, warrant, or make any representations regarding the accuracy, quality, reliability, or legality of any third-party websites, products, or services. If you decide to access any third-party content linked from the Avail documentation, you do so entirely at your own risk and subject to the terms and conditions of use for such products and services. Avail reserves the right to withdraw such references and links without notice.

--- a/pages/docs/clash-of-nodes/dymension.mdx
+++ b/pages/docs/clash-of-nodes/dymension.mdx
@@ -69,7 +69,7 @@ For developers who previously ran RollApps and are looking to migrate to the Ava
    roller keys list
    ```
 
-1. **Fund Your Avail Address**: With your Avail address in hand, head to the Avail faucet to secure the necessary funding for your RollApp on the Goldberg network. Follow the **[<ins>faucet guide instructions</ins>](/about/faucet)** to deposit testnet tokens into your Avail address.
+1. **Fund Your Avail Address**: With your Avail address in hand, head to the Avail faucet to secure the necessary funding for your RollApp on the Goldberg network. Follow the **[<ins>faucet guide instructions</ins>](/docs/end-user-guide/faucet)** to deposit testnet tokens into your Avail address.
 
 1. **Restart All Services**: Once the Avail address is funded and the network endpoint updated, you can restart all Roller services.
    This restart will initiate your RollApp on the Avail Goldberg network, completing the migration process.
@@ -173,7 +173,7 @@ For developers who previously ran RollApps and are looking to migrate to the Ava
 
 1. **Fund Your RollApp Addresses**: To fund the Dymension addresses, follow these steps in the official **[<ins>Dymension documentation</ins>](https://docs.dymension.xyz/build/quick-start/roller-quick/initialize#address-funding)**.
 
-1. **Fund Your Avail Account**: You'll also need to fund your Avail account using the Avail faucet available on the **[<ins>official Avail Discord</ins>](https://discord.com/invite/availproject)**. For detailed guidance, visit the **[<ins>Avail Faucet Guide</ins>](/docs/about/faucet.md)** and follow the provided instructions.
+1. **Fund Your Avail Account**: You'll also need to fund your Avail account using the Avail faucet available on the **[<ins>official Avail Discord</ins>](https://discord.com/invite/availproject)**. For detailed guidance, visit the **[<ins>Avail Faucet Guide</ins>](/docs/end-user-guide/faucet)** and follow the provided instructions.
 
   
   <Callout type="warning" emoji="⚠️">

--- a/pages/docs/clash-of-nodes/overview.mdx
+++ b/pages/docs/clash-of-nodes/overview.mdx
@@ -58,7 +58,7 @@ available **[<ins>here</ins>](/docs/clash-of-nodes/rules.mdx)**.
 This will ensure a fair and enjoyable experience for all participants.
 </Callout>
 
-If you're new to Avail, check out the [<ins>New User</ins>](/docs/end-user-guide/accounts) and [<ins>Quickstart</ins>](/docs/quickstart) guides.
+If you're new to Avail, check out the [<ins>End User</ins>](/docs/end-user-guide/accounts) and [<ins>Quickstart</ins>](/docs/build-with-avail/quickstart) guides.
 
 ### 1. Show Your Interest
 
@@ -88,7 +88,7 @@ For instructions on setting up and running nodes on the Avail network, please re
 | Node Type      | Guide Document                                                                  |
 | -------------- | ------------------------------------------------------------------------------- |
 | Light Client   | [<ins>How to Run a Light Client</ins>](/docs/operate-a-node/run-a-light-client/0010-light-client) |
-| Validator Node | [<ins>How to Become a Validator</ins>](/docs/operate-a-node/become-a-validator/0000-already-running-full-node)           |
+| Validator Node | [<ins>How to Become a Validator</ins>](/docs/operate-a-node/become-a-validator)           |
 
 If you require more information on node types within the Avail network, please consult the
 [<ins>Node Types Comparison document</ins>](/docs/operate-a-node/node-types).

--- a/pages/docs/end-user-guide/balance-transfers.mdx
+++ b/pages/docs/end-user-guide/balance-transfers.mdx
@@ -20,7 +20,7 @@ import { Callout } from 'nextra/components'
 
 ## Overview
 
-Balance transfers are a method for transferring funds from one account to another. This guide will walk you through the process using [<ins>Avail-JS UI</ins>](https://goldberg.avail.tools/). Before you begin, ensure you have [<ins>created an account</ins>](/about/accounts) and have [<ins>funds available</ins>](/about/faucet) for transfer.
+Balance transfers are a method for transferring funds from one account to another. This guide will walk you through the process using [<ins>Avail-JS UI</ins>](https://goldberg.avail.tools/). Before you begin, ensure you have [<ins>created an account</ins>](/docs/end-user-guide/accounts) and have [<ins>funds available</ins>](/docs/end-user-guide/faucet) for transfer.
 
 <Callout type="info">
 CLASH OF NODES<br/>

--- a/pages/docs/operate-a-node/become-a-validator/backup-your-validator.mdx
+++ b/pages/docs/operate-a-node/become-a-validator/backup-your-validator.mdx
@@ -73,4 +73,4 @@ EQUIVIVOCAITON RISK<br/>
 Never run two nodes with identical keys at the same time to avoid double-signing.
 </Callout>
 
-This method is not recommended for routine transitions between nodes. For safer alternatives, consult the [Upgrading Guide](/docs/operate/validator/0060-validator-upgrade.mdx).
+This method is not recommended for routine transitions between nodes. For safer alternatives, consult the [Upgrading Guide](/docs/operate-a-node/become-a-validator/upgrade-your-validator).

--- a/pages/docs/operate-a-node/become-a-validator/upgrade-your-validator.mdx
+++ b/pages/docs/operate-a-node/become-a-validator/upgrade-your-validator.mdx
@@ -31,7 +31,7 @@ sudo systemctl stop avail.service
 ```
 
 - Locate your Avail binary, create a backup of the current binary, and then uninstall the existing binary by deleting the binary. Proceed to download the most recent binary announced in Discord, which will replace the previous binary version.
-  To provide an example, assuming your existing binary is located at `/home/avail/avail-node/` and is named `data-avail`, and you used the [validator](/category/run-a-validator-node/) setup guidelines while obtaining a pre-built binary from the Avail GitHub repository, proceed as outlined below.
+  To provide an example, assuming your existing binary is located at `/home/avail/avail-node/` and is named `data-avail`, and you used the [validator](/docs/operate-a-node/become-a-validator) setup guidelines while obtaining a pre-built binary from the Avail GitHub repository, proceed as outlined below.
 
 ```
 cd /home/avail/avail-node/

--- a/pages/docs/operate-a-node/run-a-full-node/0040-rpc-node.mdx
+++ b/pages/docs/operate-a-node/run-a-full-node/0040-rpc-node.mdx
@@ -21,7 +21,7 @@ This guide offers a walkthrough for configuring and running an RPC node, enablin
 BEFORE YOU START<br/>
 **Ensure that you meet the [<ins>system requirements</ins>](/docs/operate-a-node/run-a-full-node/requirements).**
 
-Before setting up an RPC node, make sure to review the [archive node setup process](/docs/operate/node/0020-full-node-binaries.mdx#archive-mode). The setup process for an RPC node is almost identical, with a few additional parameters to enable RPC functionality.
+Before setting up an RPC node, make sure to review the [archive node setup process](/docs/operate-a-node/run-a-full-node/full-node/0020-full-node-binaries). The setup process for an RPC node is almost identical, with a few additional parameters to enable RPC functionality.
 </Callout>
 
 ## Configuration Parameters


### PR DESCRIPTION
Found out about this free link checker tool that uncovered a bunch of broken links in our docs:
[https://www.brokenlinkcheck.com/broken-links.php](https://www.brokenlinkcheck.com/broken-links.php).

Used it to generate this report:

<img width="1157" alt="image" src="https://github.com/availproject/docs/assets/56264430/8147b5a4-157e-4446-9541-6dd1e760702f">

This PR fixes about half of these links, and I need some clarification for the rest. Will push another PR removing/fixing the rest of the broken links.