### PR TITLE
Pushing urgent commit to fix broken links

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,6 +5,22 @@ export function middleware(request: NextRequest) {
 const { origin } = request.nextUrl
   const redirects = [
     {
+      source: '/docs/the-avail-trinity',
+      destination: `${origin}/docs/introduction-to-avail`,
+    },
+    {
+      source: '/docs/the-avail-trinity/avail-da',
+      destination: `${origin}/docs/introduction-to-avail/avail-da`,
+    },
+    {
+      source: '/docs/the-avail-trinity/avail-fusion',
+      destination: `${origin}/docs/introduction-to-avail/avail-fusion`,
+    },
+    {
+      source: '/docs/the-avail-trinity/avail-nexus',
+      destination: `${origin}/docs/introduction-to-avail/avail-nexus`,
+    },
+    {
       source: '/about/introduction',
       destination: `${origin}/docs/introduction-to-avail`,
     },


### PR DESCRIPTION
Scott brought to notice that the older avail-trinity links were not working since the narrative change towards `unification` was implemented in the docs.

Although this commit will fix this particular breakage, what needs to happen is a bit of an upgrade to my docs process.

From now on, whenever I move or delete any pages I will try to put in redirects wherever possible. This won't be possible all the time of course, but something >> nothing.

This is to prevent wasting SEO.