### PR TITLE
Added recommendation for devs to not use some RPCs directly

### DIFF
--- a/app/api-reference/avail-node-api/_meta.ts
+++ b/app/api-reference/avail-node-api/_meta.ts
@@ -1,50 +1,60 @@
 export default {
-        "Data availability pallet": {
-            "type": "separator",
-            "title": "Data availability pallet"
-         },
-    
-        "da-create-application-key": "Create a new App ID on Avail DA",
-        "da-submit-data": "Submit new data to Avail DA",
-        "da-app-keys": "Fetch App IDs from Avail DA",
-        "da-next-app-id": "Fetch the next available App ID on Avail DA",
-        
-        "Balances pallet": {
-            "type": "separator",
-            "title": "Balances pallet"
-         },
-    
-        "balances-transfer-keep-alive": "Transfer funds while ensuring min balance for sender",
-        "balances-transfer-allow-death": "Transfer funds without ensuring min balance for sender",
-        "balances-transfer-all": "Transfer all funds from one account to another",
-        "system-account": "Fetch balances and other information for an account",
-    
-        "Staking pallet": {
-            "type": "separator",
-            "title": "Staking pallet"
-         },
-    
-        "staking-active-era": "Fetch information on the active era",
-        "staking-bond": "Bond AVAIL tokens on Avail DA",
-        "staking-nominate": "Nominate staked AVAIL tokens to one or more validators",
-        "staking-validate": "Become a validator on Avail DA",
-        "staking-chill": "Stop validating on Avail DA",
-        "staking-unbond": "Unbond AVAIL tokens from Avail DA",
-        "nomination-pools": {
-            "type": "separator",
-            "title": "Nomination Pools pallet"
-         },
-    
+  "Data availability pallet": {
+    type: "separator",
+    title: "Data availability pallet",
+  },
+
+  "da-create-application-key": "Create a new App ID on Avail DA",
+  "da-submit-data": "Submit new data to Avail DA",
+  "da-app-keys": "Fetch App IDs from Avail DA",
+  "da-next-app-id": "Fetch the next available App ID on Avail DA",
+
+  "Balances pallet": {
+    type: "separator",
+    title: "Balances pallet",
+  },
+
+  "balances-transfer-keep-alive":
+    "Transfer funds while ensuring min balance for sender",
+  "balances-transfer-allow-death":
+    "Transfer funds without ensuring min balance for sender",
+  "balances-transfer-all": "Transfer all funds from one account to another",
+  "system-account": "Fetch balances and other information for an account",
+
+  "Staking pallet": {
+    type: "separator",
+    title: "Staking pallet",
+  },
+
+  "staking-active-era": "Fetch information on the active era",
+  "staking-bond": "Bond AVAIL tokens on Avail DA",
+  "staking-nominate": "Nominate staked AVAIL tokens to one or more validators",
+  "staking-validate": "Become a validator on Avail DA",
+  "staking-chill": "Stop validating on Avail DA",
+  "staking-unbond": "Unbond AVAIL tokens from Avail DA",
+  "nomination-pools": {
+    type: "separator",
+    title: "Nomination Pools pallet",
+  },
+
   "nomination-pools-join": "Join a nomination pool",
   "nomination-pools-create": "Create a new nomination pool",
-  "nomination-pools-create-with-pool-id": "Create a new nomination pool with a specific pool ID",
+  "nomination-pools-create-with-pool-id":
+    "Create a new nomination pool with a specific pool ID",
   "nomination-pools-nominate": "Nominate validator(s) for your nomination pool",
 
   "RPC Calls": {
-    "type": "separator",
-    "title": "RPC Calls"
- },
+    type: "separator",
+    title: "RPC Calls",
+  },
 
- "chain-get-block": "Fetch block data using different calls",
- 
+  "chain-get-block": "Fetch block data using different calls",
+
+  "author-submit-extrinsic": {
+    display: "hidden",
+  },
+
+  "author-submit-and-watch-extrinsic": {
+    display: "hidden",
+  },
 };

--- a/app/api-reference/avail-node-api/author-submit-and-watch-extrinsic/page.mdx
+++ b/app/api-reference/avail-node-api/author-submit-and-watch-extrinsic/page.mdx
@@ -1,0 +1,21 @@
+---
+title: "author-submit-and-watch-extrinsic"
+description: "Manually submit an extrinsic to the network and wait for finalization"
+keywords: ["author_submitAndWatchExtrinsic", "submitAndWatchExtrinsic", "submitAndWatch"]
+---
+
+import { Callout } from 'nextra/components'
+
+# Manually submit an extrinsic to the network and wait for finalization
+
+<Callout type="error">
+**`author_submitAndWatchExtrinsic` IS NOT RECOMMENDED FOR USE RIGHT NOW**<br/>
+
+1. Avail builds on top of the [Polkadot SDK](https://docs.polkadot.com/develop/parachains/intro-polkadot-sdk/#substrate) (formerly known as Substrate)
+and implements most of it's underlying calls and extrinsics.
+2. The `author_submitAndWatchExtrinsic` RPC call is known to be buggy and unreliable, and as such, not recommended for use.
+3. We recommend most devs [use our dedicated SDKs](/api-reference/avail-node-api) instead of trying to use this RPC call directly.
+4. You can read more about the problem in this Github issue: https://github.com/paritytech/subxt/issues/1668
+5. Since the problem is upstream, we can't fix it directly.
+6. We will keep this page updated with any new information :) 
+</Callout>

--- a/app/api-reference/avail-node-api/author-submit-extrinsic/page.mdx
+++ b/app/api-reference/avail-node-api/author-submit-extrinsic/page.mdx
@@ -1,0 +1,22 @@
+---
+title: "author-submit-extrinsic"
+description: "Manually Submit an extrinsic to the network"
+keywords: ["author_submitExtrinsic", "submitExtrinsic"]
+---
+
+import { Callout } from 'nextra/components'
+
+# Manually submit an extrinsic to the network
+
+<Callout type="info">
+**WE RECOMMEND USING THE AVAIL SDKs DIRECTLY**<br/>
+1. The `author_submitExtrinsic` RPC call is a low-level API that allows you to manually submit any extrinsic to the Avail network using a signed hash.
+2. We recommend using our dedicated SDKs instead of using this RPC call directly for convenience.
+3. The SDKs themselves use this RPC call internally, and offer a higher level of abstraction for interacting with the network.
+</Callout>
+
+<Callout type="info">
+**KNOW THE DIFFERENCE**<br/>
+1. `author_submitExtrinsic` & `author_submitAndWatchExtrinsic` are different RPC calls that serve different, but similar purposes.
+2. We recommend not using the latter directly either. You can read about the problems with it [in this page in our docs](/api-reference/avail-node-api/author-submit-and-watch-extrinsic).
+</Callout>


### PR DESCRIPTION
1. `author_submitExtrinsic` & `author_submitAndWatchExtrinsic` RPC calls are not recommended for use by most devs directly for different reasons.
2. This PR adds two hidden pages to elaborate the recommendation.