### PR TITLE
Polish the Nexus SDK API Reference doc contents

### DIFF
--- a/app/api-reference/_meta.ts
+++ b/app/api-reference/_meta.ts
@@ -8,31 +8,31 @@ export default {
     display: "hidden",
   },
 
-  "avail-node-api": "Avail node API reference",
+  "avail-node-api": "Avail Node API",
 
   "---": {
     type: "separator",
   },
 
-  "avail-lc-api": "Avail light client API reference",
+  "avail-lc-api": "Avail Light Client API",
 
   "----": {
     type: "separator",
   },
 
-  "avail-bridge-api": "Avail bridge API reference",
+  "avail-bridge-api": "Avail Bridge API",
 
   "------": {
     type: "separator",
   },
 
-  "avail-nexus-sdk": "Avail Nexus SDK reference",
+  "avail-nexus-sdk": "Avail Nexus SDK API",
 
   "-------": {
     type: "separator",
   },
 
-  "avail-turbo-da-api": "Turbo DA API reference",
+  "avail-turbo-da-api": "Turbo DA API",
 
   "--------": {
     type: "separator",

--- a/app/api-reference/avail-nexus-sdk/_meta.ts
+++ b/app/api-reference/avail-nexus-sdk/_meta.ts
@@ -1,6 +1,6 @@
 export default {
 
-    "overview": "Getting Started",
-    "examples": "Important Examples",
+    "overview": "Get Started",
+    "examples": "Examples",
     "api-reference": "API Reference",
 }

--- a/app/api-reference/avail-nexus-sdk/api-reference/page.mdx
+++ b/app/api-reference/avail-nexus-sdk/api-reference/page.mdx
@@ -6,18 +6,17 @@ image: '/img/docs-link-preview.png'
 
 import { Callout, Steps, Tabs } from 'nextra/components'
 
-# Avail Nexus SDK configuration & API reference
+# Avail Nexus SDK API Reference
 
 The Avail Nexus SDK provides a comprehensive set of APIs for cross-chain bridging, token transfers, and balance management across multiple EVM chains.
 
-## Configuration options
+## Configuration Options
 
-### Supported chains
+### Supported Chains
 
 <Tabs items={['Mainnet', 'Testnet']}>
 
 <Tabs.Tab>
-#### Mainnet Chains
 
 | Network   | Chain ID | Native Currency | Status |
 | --------- | -------- | --------------- | ------ |
@@ -31,8 +30,6 @@ The Avail Nexus SDK provides a comprehensive set of APIs for cross-chain bridgin
 </Tabs.Tab>
 
 <Tabs.Tab>
-
-#### Testnet Chains
 
 | Network          | Chain ID | Native Currency | Status |
 | ---------------- | -------- | --------------- | ------ |
@@ -116,8 +113,6 @@ const executeResult = await sdk.execute({
 });
 ```
 
-
-
 ## Core API Methods
 
 ### Initialization
@@ -135,7 +130,7 @@ const sdk = new NexusSDK({ network: 'testnet' as NexusNetwork });
 await sdk.initialize(window.ethereum); // Returns: Promise<void>
 ```
 
-### Balance Operations
+### Unified Balance
 
 ```typescript showLineNumbers filename="Typescript"
 import type { UserAsset, TokenBalance } from @avail-project/nexus;
@@ -147,7 +142,7 @@ const balances: UserAsset[] = await sdk.getUnifiedBalances();
 const usdcBalance: UserAsset | undefined = await sdk.getUnifiedBalance('USDC');
 ```
 
-### Bridge Operations
+### Bridge
 
 ```typescript showLineNumbers filename="Typescript"
 import type { BridgeParams, BridgeResult, SimulationResult } from @avail-project/nexus;
@@ -167,7 +162,7 @@ const simulation: SimulationResult = await sdk.simulateBridge({
 });
 ```
 
-### Transfer Operations
+### Transfer
 
 ```typescript showLineNumbers filename="Typescript"
 import type { TransferParams, TransferResult } from @avail-project/nexus;
@@ -184,7 +179,7 @@ const result: TransferResult = await sdk.transfer({
 const simulation: SimulationResult = await sdk.simulateTransfer(transferParams);
 ```
 
-### Execute Operations
+### Execute
 
 ```typescript showLineNumbers filename="Typescript"
 import type {
@@ -263,7 +258,7 @@ console.log('Approval required:', simulation.metadata?.approvalRequired);
 console.log('Bridge receive amount:', simulation.metadata?.bridgeReceiveAmount);
 ```
 
-### Allowance Management
+### Allowance
 
 ```typescript showLineNumbers filename="Typescript"
 import type { AllowanceResponse } from @avail-project/nexus;
@@ -278,7 +273,7 @@ await sdk.setAllowance(137, ['USDC'], 1000000n);
 await sdk.revokeAllowance(137, ['USDC']);
 ```
 
-### Intent Management
+### Intent
 
 ```typescript showLineNumbers filename="Typescript"
 import type { RequestForFunds } from @avail-project/nexus;
@@ -325,7 +320,7 @@ const hexChainId: string = sdk.utils.chainIdToHex(137);
 const decimalChainId: number = sdk.utils.hexToChainId('0x89');
 ```
 
-### Event Handling
+### Events
 
 ```typescript showLineNumbers filename="Typescript"
 import type { OnIntentHook, OnAllowanceHook, EventListener } from '@avail-project/nexus';
@@ -425,8 +420,6 @@ The SDK now emits exactly two event names around bridgeAndExecute():
 This replaces the legacy `BRIDGE_*`, `APPROVAL_*`, `EXECUTE_*`, `OPERATION_*`, and `TRANSFER_*` events.
 </Callout>
 
-
-
 ### Provider Methods
 
 ```typescript showLineNumbers filename="Typescript"
@@ -507,7 +500,7 @@ console.log('Gas used:', result.gasUsed);
 console.log('Confirmations:', result.confirmations);
 ```
 
-### Bridge and Execute with Error Handling
+### Handle Bridge & Execute Errors
 
 ```typescript showLineNumbers filename="Typescript"
 import type { BridgeAndExecuteResult } from '@avail-project/nexus';
@@ -543,7 +536,6 @@ try {
   }
 }
 ```
-
 ### Complete Portfolio Management
 
 ```typescript showLineNumbers filename="Typescript"
@@ -565,7 +557,6 @@ for (const asset of balances) {
   }
 }
 ```
-
 ## Error Handling
 
 ```typescript showLineNumbers filename="Typescript"
@@ -591,12 +582,11 @@ try {
   }
 }
 ```
-
 ## Troubleshooting
 
 ### Common Issues
 
-1. **SDK not initialized**: Always call `await sdk.initialize(provider)` before using other methods
-2. **Unsupported chain/token**: Check supported chains and tokens using `sdk.isSupportedChain()` and `sdk.isSupportedToken()`
-3. **Insufficient allowance**: Use allowance management methods to check and set appropriate allowances
-4. **Provider issues**: Ensure your Web3 provider is properly connected and on a supported network
+1. **SDK not initialized**: Always call `await sdk.initialize(provider)` before using other methods.
+2. **Unsupported chain/token**: Check supported chains and tokens using `sdk.isSupportedChain()` and `sdk.isSupportedToken()`.
+3. **Insufficient allowance**: Use allowance management methods to check and set appropriate allowances.
+4. **Provider issues**: Ensure your Web3 provider is properly connected and on a supported network.

--- a/app/api-reference/avail-nexus-sdk/examples/_meta.ts
+++ b/app/api-reference/avail-nexus-sdk/examples/_meta.ts
@@ -1,7 +1,7 @@
 export default {
 
-    "fetch-unified-balances": "Fetch unified balance using the Nexus SDK",
-    "transfer": "Transfer tokens using the Nexus SDK",
-    "bridge-tokens": "Bridge tokens using the Nexus SDK",
-    "bridge-and-execute": "Bridge & Execute with the Nexus SDK"
+    "fetch-unified-balances": "Unified Balance",
+    "transfer": "Transfer",
+    "bridge-tokens": "Bridge",
+    "bridge-and-execute": "Bridge & Execute"
 }

--- a/app/api-reference/avail-nexus-sdk/examples/bridge-and-execute/page.mdx
+++ b/app/api-reference/avail-nexus-sdk/examples/bridge-and-execute/page.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bridge and Execute using the BridgeAndExecuteButton widget of the Nexus SDK"
+title: "Bridge and Execute with BridgeAndExecuteButton widget"
 ---
 
 import { Callout, Tabs } from 'nextra/components'

--- a/app/api-reference/avail-nexus-sdk/examples/bridge-tokens/page.mdx
+++ b/app/api-reference/avail-nexus-sdk/examples/bridge-tokens/page.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bridge tokens using the BridgeButton widget of the Nexus SDK"
+title: "Bridge tokens with BridgeButton widget"
 ---
 
 import { Callout, Tabs } from 'nextra/components'

--- a/app/api-reference/avail-nexus-sdk/examples/fetch-unified-balances/page.mdx
+++ b/app/api-reference/avail-nexus-sdk/examples/fetch-unified-balances/page.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Fetch unified balance of a user using the Nexus SDK"
+title: "Fetch unified balance of a user"
 ---
 
 import { Callout, Steps, Tabs } from 'nextra/components'
@@ -11,7 +11,6 @@ import { Callout, Steps, Tabs } from 'nextra/components'
 
 You can find the SDK setup instructions in the [Overview](/api-reference/avail-nexus-sdk/overview) page.
 </Callout>
-
 
 Use these functions to fetch consolidated token balances across all supported chains. 
 This shows users their total available liquidity without needing to check each chain individually.

--- a/app/api-reference/avail-nexus-sdk/examples/transfer/page.mdx
+++ b/app/api-reference/avail-nexus-sdk/examples/transfer/page.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Transfer tokens using the TransferButton widget of the Nexus SDK"
+title: "Transfer tokens with TransferButton widget"
 ---
 
 import { Callout, Tabs } from 'nextra/components'

--- a/app/api-reference/avail-nexus-sdk/overview/page.mdx
+++ b/app/api-reference/avail-nexus-sdk/overview/page.mdx
@@ -1,17 +1,18 @@
 ---
-title: "Getting started with the Avail Nexus SDK"
+title: "Get Started"
 ---
 
-import { Callout, Steps, Tabs } from 'nextra/components'
+import { Callout, Steps, Tabs } from 'nextra/components';
 
-# Getting started with the Avail Nexus SDK
+# Get Started
 
 <Callout type="info">
-**Note:** We built a React demo app that uses the Avail Nexus SDK UI components to implement a unified Web3 experience.
+    We built a React demo app that uses the Avail Nexus SDK UI components to implement a unified Web3 experience.
 
-1. You can use the app here: [nexus-ui-components-demo.vercel.app](https://nexus-ui-components-demo.vercel.app/)
-2. You can find the code for the app here: [availproject/nexus-ui-components-demo](https://github.com/availproject/nexus-ui-components-demo).
+    1. You can use the app here: [`nexus-ui-components-demo.vercel.app`](https://nexus-ui-components-demo.vercel.app/)
+    2. You can find the code for the app here: [`availproject/nexus-ui-components-demo`](https://github.com/availproject/nexus-ui-components-demo)
 </Callout>
+
 
 The Avail Nexus SDK provides both headless functionality and pre-built React UI components. This guide covers the **React UI components** which offer the fastest way to integrate chain abstraction into your React app.
 
@@ -21,9 +22,11 @@ The SDK provides `BridgeButton`, `TransferButton`, and `BridgeAndExecuteButton` 
 
 <Steps>
 
-### Wrap your app with `NexusProvider`
+### Get `NexusProvider`
 
-Add the `NexusProvider` to your app's root component to enable SDK functionality (`layout.tsx` for Next.js, `App.tsx` for Remix, etc.):
+Wrap your app with the `NexusProvider`.
+
+Enable the Nexus SDK functionality by adding the `NexusProvider` to your app's root component. (For e.g.,`layout.tsx` in Next.js or `App.tsx` in Remix, etc.):
 
 ```tsx showLineNumbers filename="__root.tsx"
 import { NexusProvider } from '@avail-project/nexus';
@@ -48,7 +51,9 @@ The demo app sets up the `NexusProvider` in the [__root.tsx](https://github.com/
 wrapping the entire application with both wallet authentication (Privy) and the Nexus provider.
 </Callout>
 
-### Forward the user's wallet provider
+### Set Wallet Provider
+
+Forward the user's wallet provider.
 
 Connect your wallet library to the Nexus SDK by forwarding the provider:
 
@@ -77,7 +82,9 @@ export function WalletBridge() {
 The demo app uses Privy and forwards the provider in [connect-wallet.tsx](https://github.com/availproject/nexus-ui-components-demo/blob/main/src/components/connect-wallet.tsx#L16).
 </Callout>
 
-### Drop a widget into your UI
+### Use UI Widget
+
+Drop a widget into your UI.
 
 Use the pre-built UI components for common chain abstraction operations. The following example
 shows how you would use the bridge, but other widgets are covered in the following pages:
@@ -97,7 +104,9 @@ import {
 </BridgeButton>
 ```
 
-### Fetch the unified balance for a user
+### Access Unified Balance
+
+Fetch the unified balance for a user.
 
 You can access the SDK directly through the `useNexus` hook to call any headless SDK methods, including balance fetching:
 

--- a/app/api-reference/avail-nexus-sdk/page.mdx
+++ b/app/api-reference/avail-nexus-sdk/page.mdx
@@ -1,34 +1,38 @@
 ---
 image: "/img/docs-link-preview.png"
-title: Avail Nexus SDK reference
+title: Avail Nexus SDK Reference
 asIndexPage: true
 ---
 
-import { Callout, Steps, Tabs } from 'nextra/components'
+import { Callout, Steps, Tabs } from 'nextra/components';
 
-# Avail Nexus SDK reference
+# Avail Nexus
 
-## Setting up the dev environment
+## Prerequisites
 
 <Callout type="info">
 **BEFORE WE START**
 
-1. The Nexus SDK is designed for browser environments and requires an injected wallet provider (e.g. MetaMask, WalletConnect, etc.)
-2. The SDK cannot be used in any server-side environments.
-3. To use the UI components of the SDK, you will need a React-based dev environment.
-4. You can find the nexus-sdk repo here: [availproject/nexus-sdk](https://github.com/availproject/nexus-sdk)
-5. You can find the Nexus SDK on npm here: [npmjs.com/package/@avail-project/nexus](https://www.npmjs.com/package/@avail-project/nexus)
+1. The Nexus SDK requires an injected wallet provider (e.g. MetaMask, WalletConnect, etc.)
+2. It is designed for client-side browser environments and **cannot be used** in any server-side environments.
+3. You will need a React-based dev environment to use the SDK UI components.
+4. GitHub: [`availproject/nexus-sdk`](https://github.com/availproject/nexus-sdk)
+5. `npm.js` Package: [`@avail-project/nexus`](https://www.npmjs.com/package/@avail-project/nexus)
 </Callout>
 
-## Setting up the dev environment
+## Dev Environment Setup
 
 <Steps>
 
-### Set up a frontend project with a React-based dev environment
+### Use React Frontend
+
+Set up a React Frontend Project.
 
 Any React-based dev environment works, including React frameworks like Next.js, Remix, Gatsby, or build tools like Vite, Create React App, and Webpack.
 
-### Install the Nexus SDK
+### Install SDK
+
+Install the Nexus SDK.
 
 Use any package manager of your choice to install the Nexus SDK:
 
@@ -57,10 +61,10 @@ pnpm add @avail-project/nexus
 </Tabs>
 
 <Callout type="info">
-We built a minimal demo app that uses the Avail Nexus SDK UI components:
+    We built a React demo app that uses the Avail Nexus SDK UI components to implement a unified Web3 experience.
 
-1. You can use the app here: [nexus-ui-components-demo.vercel.app](https://nexus-ui-components-demo.vercel.app/)
-2. You can find the code for the app here: [availproject/nexus-ui-components-demo](https://github.com/availproject/nexus-ui-components-demo).
+    1. You can use the app here: [`nexus-ui-components-demo.vercel.app`](https://nexus-ui-components-demo.vercel.app/)
+    2. You can find the code for the app here: [`availproject/nexus-ui-components-demo`](https://github.com/availproject/nexus-ui-components-demo)
 </Callout>
 
 </Steps>

--- a/app/api-reference/start-here/page.mdx
+++ b/app/api-reference/start-here/page.mdx
@@ -18,7 +18,7 @@ export default function MdxLayout(props) {
 <Callout type="warning">
 
 1. This section is dedicated towards providing a detailed API reference for all of Avail's APIs and SDKs.
-2. If you have been working with older versions of Avail's SDKs, pleasre refer to the menu in next to the search bar to access the old API docs.
+2. If you are working with older versions of Avail's SDKs, please refer to the menu next to the search bar to access the old API docs.
 
 </Callout>
 <br/>
@@ -27,7 +27,7 @@ export default function MdxLayout(props) {
 
 This entire section is dedicated towards providing a detailed API reference for all of Avail's dev tooling.
 
-We currently document the following APIs, feel free to reach out to us on [our Discord server](https://discord.gg/AvailProject) if there are any error, or if something you need is missing:
+We currently document the following APIs: 
 
 <Cards num={4}>
   <Cards.Card icon={<FileIcon />} title="Avail node API" href="/api-reference/avail-node-api" />
@@ -36,3 +36,6 @@ We currently document the following APIs, feel free to reach out to us on [our D
   <Cards.Card icon={<FileIcon />} title="Avail Nexus API" href="/api-reference/avail-nexus-sdk" />
   <Cards.Card icon={<FileIcon />} title="Turbo DA API" href="/api-reference/avail-turbo-da-api" />
 </Cards>
+
+Questions? Errors? Something missing?
+Feel free to reach out to us on [our Discord server](https://discord.gg/AvailProject).


### PR DESCRIPTION
Polished the Nexus SDK API Reference docs - better beta docs.

> Removed heading sentences, upgraded to action/verb format, concise
> Fixed typos and language errors
> Highlighted repos, packages for download
> Aligned tone, without losing any info/KB

For example:

Before 
<img width="1290" height="827" alt="Screenshot 2025-07-10 at 10 58 22 PM" src="https://github.com/user-attachments/assets/33d7696c-ae62-43bf-8610-7f858dde332a" />


After
![Uploading Screenshot 2025-07-10 at 10.57.37 PM.png…]()


